### PR TITLE
Change API URL from HTTP to HTTPS

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -430,7 +430,7 @@
         "method": "GET",
         "ret": "obj",
         "paytoqs": "ignore",
-        "url": "http://{{{envoyaddress}}}/api/v1/production",
+        "url": "https://{{{envoyaddress}}}/api/v1/production",
         "tls": "",
         "persist": false,
         "proxy": "",


### PR DESCRIPTION
As of firmware D8.3.5286, the http-link doesn't work anymore.